### PR TITLE
Issue 2 score jack as 10

### DIFF
--- a/src/main/java/net/kemitix/blackjack/model/AbstractCardHand.java
+++ b/src/main/java/net/kemitix/blackjack/model/AbstractCardHand.java
@@ -65,13 +65,14 @@ abstract class AbstractCardHand implements CardHand {
         val aces = new AtomicInteger();
         score = hand.stream().mapToInt(card -> {
             int value = card.getValue();
+            // convert face cards to 10
+            if (value >= Card.JACK_CARD) {
+                value = FACE_CARD_VALUE;
+            }
+            // count aces as high initially
             if (value == LOW_ACE_VALUE) {
                 aces.incrementAndGet();
                 value = HIGH_ACE_VALUE;
-            }
-            // convert face cards to 10
-            if (value > HIGH_ACE_VALUE) {
-                value = FACE_CARD_VALUE;
             }
             return value;
         }).sum();

--- a/src/main/java/net/kemitix/blackjack/model/Card.java
+++ b/src/main/java/net/kemitix/blackjack/model/Card.java
@@ -12,9 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Card {
 
-    private static final int ACE_CARD = 1;
+    public static final int JACK_CARD = 11;
 
-    private static final int JACK_CARD = 11;
+    private static final int ACE_CARD = 1;
 
     private static final int QUEEN_CARD = 12;
 

--- a/src/test/java/net/kemitix/blackjack/model/AbstractCardHandTest.java
+++ b/src/test/java/net/kemitix/blackjack/model/AbstractCardHandTest.java
@@ -34,6 +34,8 @@ public class AbstractCardHandTest {
 
     private CardHand cardHand9And8And5;
 
+    private CardHand cardHand9AndJack;
+
     @Mock
     private CardPile cardPile;
 
@@ -49,6 +51,7 @@ public class AbstractCardHandTest {
         val cardAceD = new Card(Suit.DIAMOND, 1);
         val cardAceS = new Card(Suit.SPADE, 1);
         val cardQueen = new Card(Suit.DIAMOND, 12);
+        val cardJack = new Card(Suit.CLUB, Card.JACK_CARD);
         cardHand3And4 = buildHand(card3, card4);
         cardHand4AndQueen = buildHand(card4, cardQueen);
         cardHand8AndAce = buildHand(card8, cardAceD);
@@ -56,6 +59,7 @@ public class AbstractCardHandTest {
         cardHand10And2Aces = buildHand(card10, cardAceD, cardAceS);
         cardHand9And8And4 = buildHand(card9, card8, card4);
         cardHand9And8And5 = buildHand(card9, card8, card5);
+        cardHand9AndJack = buildHand(card9, cardJack);
     }
 
     private CardHand buildHand(final Card... cards) {
@@ -101,6 +105,7 @@ public class AbstractCardHandTest {
         softly.assertThat(cardHand10And2Aces.getScore()).isEqualTo(12);
         softly.assertThat(cardHand9And8And4.getScore()).isEqualTo(21);
         softly.assertThat(cardHand9And8And5.getScore()).isEqualTo(22);
+        softly.assertThat(cardHand9AndJack.getScore()).isEqualTo(19);
         softly.assertAll();
     }
 


### PR DESCRIPTION
Face cards were being treated as if they were in the range 12-14, rather than 11-13. This was causing the Jack card, with a value of 11, not to be scored as 10 but as 11. 

To make the value more consistent the `Card.JACK_CARD` constant has been made public and is used in the comparison test.