### PR TITLE
model.DefaultCardShow: when shoe is empty add discards then deal

### DIFF
--- a/src/main/java/net/kemitix/blackjack/model/DefaultCardShoe.java
+++ b/src/main/java/net/kemitix/blackjack/model/DefaultCardShoe.java
@@ -67,14 +67,14 @@ class DefaultCardShoe implements CardShoe {
     @Override
     public Card deal() {
         Card card = null;
-        if (contents.size() > 0) {
-            card = contents.remove(random.nextInt(contents.size()));
-        }
         if (contents.size() <= minimumSize) {
             val discards = discardPile.remove();
             if (discards != null) {
                 contents.addAll(discards);
             }
+        }
+        if (contents.size() > 0) {
+            card = contents.remove(random.nextInt(contents.size()));
         }
         return card;
     }

--- a/src/test/java/net/kemitix/blackjack/model/DefaultCardShoeTest.java
+++ b/src/test/java/net/kemitix/blackjack/model/DefaultCardShoeTest.java
@@ -82,4 +82,15 @@ public class DefaultCardShoeTest {
         assertThat(cardShoe.deal()).isNull();
     }
 
+    @Test
+    public void whenShoeIsEmptyAndDiscardIsNotLoadDiscardsBeforeDealing() {
+        //given
+        // cardShoe is empty
+        val discardedCard = new Card(Suit.CLUB, 4);
+        discardPile.add(Collections.singleton(discardedCard));
+        //when
+        val dealtCard = cardShoe.deal();
+        //then
+        assertThat(dealtCard).isSameAs(discardedCard);
+    }
 }


### PR DESCRIPTION
Previously the shoe would select a card from the shoe's contents before checking if it should reshuffle in the discard pile. This resulted in the shoe returning `null` (i.e. no card) even as it added cards from the discard pile.

Now the discard pile is added to the shoe, if the shuffle limit is reached, before attempting to select a card.